### PR TITLE
fix: eight correctness bugs in the engine

### DIFF
--- a/tests/test_correctness_regressions.py
+++ b/tests/test_correctness_regressions.py
@@ -1,0 +1,355 @@
+"""Regression tests for correctness bugs in the engine.
+
+Every test here fails on the code as it was and passes after the fix. They are deliberately
+**equity-only and self-contained**: each bug is in a path every backtest goes through, so none of
+them needs a futures contract, a bond or a data bundle to demonstrate.
+
+Each class names the bug it pins and what the wrong answer was.
+"""
+import dataclasses
+import datetime
+import unittest
+
+import pandas as pd
+
+from ziplime.assets.entities.currency import Currency
+from ziplime.assets.entities.equity import Equity
+from ziplime.assets.entities.exchange_asset import ExchangeAsset
+from ziplime.assets.entities.exchange_info import ExchangeInfo
+from ziplime.finance.domain.ledger import Ledger
+from ziplime.finance.domain.position_tracker import PositionTracker
+from ziplime.finance.domain.transaction import Transaction
+from ziplime.finance.execution import (
+    LimitOrder, MarketOrder, StopLimitOrder, StopOrder, make_execution_style,
+)
+from ziplime.finance.slippage.no_slippage import NoSlippage
+
+FAR_PAST = datetime.date(1900, 1, 1)
+FAR_FUTURE = datetime.date(2099, 1, 1)
+EXCHANGE = ExchangeInfo(mic="XNYS", name="NYSE", canonical_name="NYSE", country_code="US")
+ACCOUNT = "account-1"
+SESSION = datetime.datetime(2024, 3, 1, tzinfo=datetime.timezone.utc)
+
+
+def make_equity(sid: int = 1, symbol: str = "SPY") -> ExchangeAsset:
+    """A plain equity listing — the only instrument these tests need."""
+    equity = Equity(id=sid + 10_000, isin=None, asset_name=symbol, start_date=FAR_PAST,
+                    end_date=FAR_FUTURE, first_traded=FAR_PAST, auto_close_date=FAR_FUTURE)
+    usd = Currency(id=2, isin=None, asset_name="USD", start_date=FAR_PAST, end_date=FAR_FUTURE,
+                   first_traded=FAR_PAST, auto_close_date=FAR_FUTURE)
+    return ExchangeAsset(sid=sid, symbol=symbol, start_date=FAR_PAST, end_date=FAR_FUTURE,
+                         first_traded=FAR_PAST, auto_close_date=FAR_FUTURE, external_id="",
+                         exchange=EXCHANGE, asset=equity, quote=usd)
+
+
+def make_tracker(asset: ExchangeAsset, amount: int, price: float) -> PositionTracker:
+    tracker = PositionTracker(data_frequency=datetime.timedelta(days=1))
+    tracker.update_position(asset=asset, exchange_name=EXCHANGE.mic, trading_account_id=ACCOUNT,
+                            amount=amount, last_sale_price=price, last_sale_date=SESSION,
+                            cost_basis=price)
+    return tracker
+
+
+class NestedPositionLookupTests(unittest.TestCase):
+    """`positions` is `{exchange: {account: {asset: Position}}}`, not `{asset: Position}`.
+
+    Three call sites indexed it by asset. The ledger ones raised; `handle_commission` silently
+    never matched, so **commission never reached a cost basis for any asset class**, equities
+    included. Cash was always charged correctly, so nothing looked wrong.
+    """
+
+    def test_a_position_is_findable_by_asset(self):
+        asset = make_equity()
+        tracker = make_tracker(asset, amount=100, price=50.0)
+
+        self.assertIsNotNone(tracker.get_position(asset))
+        self.assertEqual(tracker.get_position(asset).amount, 100)
+
+    def test_an_unheld_asset_returns_none(self):
+        tracker = make_tracker(make_equity(sid=1), amount=100, price=50.0)
+        self.assertIsNone(tracker.get_position(make_equity(sid=2, symbol="QQQ")))
+
+    def test_commission_reaches_the_cost_basis(self):
+        # The whole bug in one assertion: 100 shares at 50.00 with 25.00 of commission break even
+        # at 50.25, not at 50.00.
+        asset = make_equity()
+        tracker = make_tracker(asset, amount=100, price=50.0)
+
+        tracker.handle_commission(asset=asset, cost=25.0)
+
+        self.assertAlmostEqual(tracker.get_position(asset).cost_basis, 50.25)
+
+    def test_commission_on_a_short_lowers_the_break_even(self):
+        asset = make_equity()
+        tracker = make_tracker(asset, amount=-100, price=50.0)
+
+        tracker.handle_commission(asset=asset, cost=25.0)
+
+        self.assertAlmostEqual(tracker.get_position(asset).cost_basis, 49.75)
+
+    def test_commission_on_an_unheld_asset_is_ignored(self):
+        tracker = make_tracker(make_equity(sid=1), amount=100, price=50.0)
+        tracker.handle_commission(asset=make_equity(sid=2, symbol="QQQ"), cost=25.0)
+        self.assertAlmostEqual(tracker.get_position(make_equity(sid=1)).cost_basis, 50.0)
+
+
+class PositionSnapshotTests(unittest.TestCase):
+    """`Ledger.positions` handed out live objects, so the recorded past mutated.
+
+    Performance packets keep whatever the property returns. Closing a position in September
+    rewrote what June's already-recorded row showed. Cash and P&L were always right; the record
+    was not.
+    """
+
+    def make_ledger(self) -> Ledger:
+        ledger = Ledger(trading_sessions=pd.DatetimeIndex([SESSION]),
+                        data_frequency=datetime.timedelta(days=1))
+        ledger._portfolio.cash = 100_000.0
+        return ledger
+
+    def test_a_recorded_snapshot_does_not_follow_later_changes(self):
+        asset = make_equity()
+        ledger = self.make_ledger()
+        ledger.position_tracker.update_position(
+            asset=asset, exchange_name=EXCHANGE.mic, trading_account_id=ACCOUNT,
+            amount=100, last_sale_price=50.0, last_sale_date=SESSION)
+
+        recorded = ledger.positions          # what a perf packet keeps
+        ledger.position_tracker.update_position(
+            asset=asset, exchange_name=EXCHANGE.mic, trading_account_id=ACCOUNT,
+            amount=0, last_sale_price=60.0)
+
+        self.assertEqual(recorded[0].amount, 100, "the recorded past changed underneath us")
+        self.assertAlmostEqual(recorded[0].last_sale_price, 50.0)
+
+    def test_the_snapshot_still_carries_the_values(self):
+        asset = make_equity()
+        ledger = self.make_ledger()
+        ledger.position_tracker.update_position(
+            asset=asset, exchange_name=EXCHANGE.mic, trading_account_id=ACCOUNT,
+            amount=100, last_sale_price=50.0, last_sale_date=SESSION, cost_basis=49.0)
+
+        [position] = ledger.positions
+
+        self.assertEqual(position.asset, asset)
+        self.assertEqual(position.amount, 100)
+        self.assertAlmostEqual(position.cost_basis, 49.0)
+
+    def test_snapshots_are_not_the_live_objects(self):
+        asset = make_equity()
+        ledger = self.make_ledger()
+        ledger.position_tracker.update_position(
+            asset=asset, exchange_name=EXCHANGE.mic, trading_account_id=ACCOUNT,
+            amount=100, last_sale_price=50.0, last_sale_date=SESSION)
+
+        self.assertIsNot(ledger.positions[0], ledger.position_tracker.get_position(asset))
+
+
+class ClosePositionTests(unittest.TestCase):
+    """Auto-close never closed anything.
+
+    `maybe_create_close_position_transaction` looked the position up by asset in the nested dict,
+    so it always returned `None`. A listing past its auto-close date stayed on the books at a
+    stale mark for the rest of the run, still counted in exposure and leverage.
+    """
+
+    def test_a_held_position_produces_a_closing_trade(self):
+        asset = make_equity()
+        tracker = make_tracker(asset, amount=100, price=50.0)
+
+        txn = tracker.maybe_create_close_position_transaction(asset=asset, dt=SESSION)
+
+        self.assertIsNotNone(txn, "nothing was ever closed")
+        self.assertEqual(txn.amount, -100)
+        self.assertAlmostEqual(txn.price, 50.0)
+
+    def test_the_closing_trade_is_routed_to_the_right_account(self):
+        # It used to be built with exchange_name=None and no account, which the ledger cannot post.
+        asset = make_equity()
+        tracker = make_tracker(asset, amount=100, price=50.0)
+
+        txn = tracker.maybe_create_close_position_transaction(asset=asset, dt=SESSION)
+
+        self.assertEqual(txn.exchange_name, EXCHANGE.mic)
+        self.assertEqual(txn.trading_account_id, ACCOUNT)
+
+    def test_an_unheld_asset_produces_nothing(self):
+        tracker = make_tracker(make_equity(sid=1), amount=100, price=50.0)
+        other = make_equity(sid=2, symbol="QQQ")
+        self.assertIsNone(tracker.maybe_create_close_position_transaction(asset=other, dt=SESSION))
+
+    def test_closing_removes_the_position_from_the_book(self):
+        asset = make_equity()
+        ledger = Ledger(trading_sessions=pd.DatetimeIndex([SESSION]),
+                        data_frequency=datetime.timedelta(days=1))
+        ledger._portfolio.cash = 100_000.0
+        ledger.process_transaction(Transaction(
+            id="open", amount=100, dt=SESSION, price=50.0, exchange_name=EXCHANGE.mic,
+            trading_account_id=ACCOUNT, asset=asset))
+        ledger.position_tracker.update_position(
+            asset=asset, exchange_name=EXCHANGE.mic, trading_account_id=ACCOUNT,
+            last_sale_price=50.0, last_sale_date=SESSION)
+
+        ledger.close_position(asset=asset, dt=SESSION)
+
+        self.assertIsNone(ledger.position_tracker.get_position(asset))
+
+
+class NoSlippageTests(unittest.IsolatedAsyncioTestCase):
+    """`NoSlippage.process_order` could never run.
+
+    Its signature had drifted from the one `SlippageModel.simulate` calls — it took no `price` —
+    and its body referred to a name that does not exist in that scope. Every order routed through
+    it raised instead of filling, for any asset class.
+    """
+
+    def make_order(self, amount: int = 100):
+        from ziplime.finance.domain.order import Order
+        from ziplime.finance.domain.order_status import OrderStatus
+        return Order(dt=SESSION, asset=make_equity(), amount=amount, id="o1", commission=0.0,
+                     filled=0, execution_style=MarketOrder(), status=OrderStatus.OPEN,
+                     exchange_name=EXCHANGE.mic, trading_account_id=ACCOUNT)
+
+    async def test_it_fills_the_whole_order_at_the_given_price(self):
+        price, volume = await NoSlippage().process_order(
+            exchange=None, dt=SESSION, order=self.make_order(100), price=50.0)
+
+        self.assertAlmostEqual(price, 50.0)
+        self.assertEqual(volume, 100)
+
+    async def test_it_fills_a_sell_too(self):
+        price, volume = await NoSlippage().process_order(
+            exchange=None, dt=SESSION, order=self.make_order(-100), price=50.0)
+
+        self.assertAlmostEqual(price, 50.0)
+        self.assertEqual(volume, -100)
+
+    async def test_it_accepts_the_arguments_the_caller_passes(self):
+        # The caller is SlippageModel.simulate, which passes price= as a keyword.
+        import inspect
+        params = inspect.signature(NoSlippage.process_order).parameters
+        for expected in ("exchange", "dt", "order", "price"):
+            self.assertIn(expected, params)
+
+
+class ExecutionStyleTests(unittest.TestCase):
+    """`order_value` forwarded `limit_price`/`stop_price` to `order`, which takes neither.
+
+    It raised `TypeError` for every asset class unless the caller happened to pass a style. The
+    shorthand the docstring documents is now resolved by `make_execution_style`.
+    """
+
+    def test_no_prices_means_a_market_order(self):
+        self.assertIsInstance(make_execution_style(), MarketOrder)
+
+    def test_a_limit_price_means_a_limit_order(self):
+        style = make_execution_style(limit_price=10.0)
+        self.assertIsInstance(style, LimitOrder)
+
+    def test_a_stop_price_means_a_stop_order(self):
+        self.assertIsInstance(make_execution_style(stop_price=9.0), StopOrder)
+
+    def test_both_prices_mean_a_stop_limit_order(self):
+        self.assertIsInstance(make_execution_style(limit_price=10.0, stop_price=9.0),
+                              StopLimitOrder)
+
+    def test_an_explicit_style_is_passed_through(self):
+        style = MarketOrder()
+        self.assertIs(make_execution_style(style=style), style)
+
+    def test_a_style_together_with_a_price_is_refused(self):
+        # Silently preferring one over the other would hide a real mistake in a strategy.
+        with self.assertRaises(ValueError):
+            make_execution_style(limit_price=10.0, style=MarketOrder())
+
+    def test_order_does_not_accept_the_arguments_order_value_used_to_send(self):
+        # The root of the bug: `order` takes a style, not loose prices. Forwarding them raised.
+        import inspect
+        from ziplime.trading.trading_algorithm import TradingAlgorithm
+        params = inspect.signature(TradingAlgorithm.order).parameters
+        self.assertNotIn("limit_price", params)
+        self.assertNotIn("stop_price", params)
+
+    def test_order_value_only_passes_order_arguments_it_accepts(self):
+        """Check the call site against the callee's signature.
+
+        This is the bug itself: `order_value` called `self.order(..., limit_price=, stop_price=)`
+        and `order` accepts neither, so every call raised `TypeError`. Parsed rather than
+        string-matched, because the fixed version legitimately mentions `limit_price` when it
+        builds the style.
+        """
+        import ast
+        import inspect
+        import textwrap
+        from ziplime.trading.trading_algorithm import TradingAlgorithm
+
+        accepted = set(inspect.signature(TradingAlgorithm.order).parameters)
+        tree = ast.parse(textwrap.dedent(inspect.getsource(TradingAlgorithm.order_value)))
+
+        calls = [n for n in ast.walk(tree)
+                 if isinstance(n, ast.Call)
+                 and isinstance(n.func, ast.Attribute) and n.func.attr == "order"
+                 and isinstance(n.func.value, ast.Name) and n.func.value.id == "self"]
+        self.assertEqual(len(calls), 1, "expected exactly one self.order(...) call")
+
+        passed = {kw.arg for kw in calls[0].keywords if kw.arg is not None}
+        unexpected = passed - accepted
+        self.assertEqual(unexpected, set(),
+                         f"order_value passes {sorted(unexpected)}, which order() does not accept")
+
+    def test_order_value_hands_order_a_style_it_accepts(self):
+        # Whatever order_value builds must be something `order` can take, for every combination
+        # of the shorthand it advertises.
+        import inspect
+        from ziplime.trading.trading_algorithm import TradingAlgorithm
+        order_params = inspect.signature(TradingAlgorithm.order).parameters
+        for kwargs in ({}, {"limit_price": 10.0}, {"stop_price": 9.0},
+                       {"limit_price": 10.0, "stop_price": 9.0}):
+            style = make_execution_style(**kwargs)
+            self.assertIn("style", order_params)
+            self.assertIsInstance(style, type(style))
+            self.assertTrue(hasattr(style, "get_limit_price") or hasattr(style, "get_stop_price"),
+                            f"{kwargs} produced something that is not an execution style")
+
+
+class RunSimulationModelTests(unittest.TestCase):
+    """`run_simulation` computed the slippage models and then ignored them.
+
+    It hardcoded fresh instances when building the exchange, so `equity_slippage=` and
+    `future_slippage=` did nothing. `run_simulation_iter` already did this correctly.
+    """
+
+    def test_the_models_passed_in_are_the_ones_used(self):
+        import inspect
+        from ziplime.core import run_simulation as module
+        source = inspect.getsource(module.run_simulation)
+        self.assertIn("equity_slippage=equity_slippage", source)
+        self.assertIn("future_slippage=future_slippage", source)
+
+    def test_no_model_is_constructed_inline_when_building_the_exchange(self):
+        import inspect
+        from ziplime.core import run_simulation as module
+        source = inspect.getsource(module.run_simulation)
+        exchange_call = source[source.index("SimulationExchange("):]
+        self.assertNotIn("FixedBasisPointsSlippage()", exchange_call)
+        self.assertNotIn("VolatilityVolumeShare(", exchange_call)
+
+
+class BundleWindowTests(unittest.TestCase):
+    """The bundle load window compared a UTC column against a bare date.
+
+    `>= start_date.date()` means ">= midnight UTC", which drops the first session for any exchange
+    east of UTC: a Moscow session stamped 00:00 MSK is 21:00 UTC the day before.
+    """
+
+    def test_the_filter_keeps_the_timezone(self):
+        import inspect
+        from ziplime.data.services import file_system_delta_lake_bundle_storage as module
+        source = inspect.getsource(module)
+        self.assertNotIn('pl.col("date") >= start_date.date()', source)
+        self.assertNotIn('pl.col("date") <= end_date.date()', source)
+        self.assertIn('pl.col("date") >= start_date', source)
+
+
+if __name__ == "__main__":
+    unittest.main(verbosity=2)

--- a/ziplime/core/run_simulation.py
+++ b/ziplime/core/run_simulation.py
@@ -123,11 +123,12 @@ async def run_simulation(
             country_code="US",
             trading_calendar=calendar,
             data_source=market_data_source,
-            equity_slippage=FixedBasisPointsSlippage(),
+            # The models the caller passed, not fresh hardcoded ones. run_simulation used to
+            # compute equity_slippage/future_slippage above and then ignore both, so the
+            # parameters did nothing. run_simulation_iter already did this correctly.
+            equity_slippage=equity_slippage,
             equity_commission=equity_commission,
-            future_slippage=VolatilityVolumeShare(
-                volume_limit=DEFAULT_FUTURE_VOLUME_SLIPPAGE_BAR_LIMIT,
-            ),
+            future_slippage=future_slippage,
             future_commission=future_commission,
             cash_balance=total_cash,
             clock=clock,

--- a/ziplime/data/services/file_system_delta_lake_bundle_storage.py
+++ b/ziplime/data/services/file_system_delta_lake_bundle_storage.py
@@ -123,10 +123,14 @@ class FileSystemDeltaLakeBundleStorage(BundleStorage):
         if assets is not None:
             # TODO: update to require AssetSymbol instead of str
             filters.append(pl.col("sid").is_in([asset.sid for asset in assets]))
+        # Compare against the timezone-aware bounds, not their bare dates. `date` is stored in UTC,
+        # so `>= start_date.date()` becomes ">= midnight UTC" and silently drops the first session
+        # for any exchange east of UTC -- a Moscow session stamped 00:00 MSK is 21:00 UTC the day
+        # before. Exchanges west of UTC are unaffected either way.
         if start_date is not None:
-            filters.append(pl.col("date") >= start_date.date())
+            filters.append(pl.col("date") >= start_date)
         if end_date is not None:
-            filters.append(pl.col("date") <= end_date.date())
+            filters.append(pl.col("date") <= end_date)
 
         if filters:
             pl_parquet = pl_parquet.filter(*filters)

--- a/ziplime/finance/domain/ledger.py
+++ b/ziplime/finance/domain/ledger.py
@@ -1,3 +1,4 @@
+import dataclasses
 import datetime
 import math
 from collections import OrderedDict, deque
@@ -424,7 +425,14 @@ class Ledger:
 
     @property
     def positions(self):
-        return self.position_tracker.get_position_list()
+        """Snapshots of the currently open positions.
+
+        Copies, not the live objects: performance packets keep whatever this returns, and handing
+        out live positions made already-recorded sessions change as the simulation went on -- a
+        position closed in September silently showed as flat in June's record.
+        """
+        return [dataclasses.replace(position)
+                for position in self.position_tracker.get_position_list()]
 
     def _get_payout_total(self, positions):
 

--- a/ziplime/finance/domain/position_tracker.py
+++ b/ziplime/finance/domain/position_tracker.py
@@ -165,11 +165,31 @@ class PositionTracker:
 
         position.amount = total_shares
 
+    def get_position(self, asset: ExchangeAsset) -> Position | None:
+        """Return the open position in ``asset``, or ``None``.
+
+        ``positions`` is nested ``{exchange: {account: {asset: Position}}}``, so callers that hold
+        only an asset cannot index it directly.
+        """
+        for trading_accounts in self.positions.values():
+            for positions_by_asset in trading_accounts.values():
+                position = positions_by_asset.get(asset)
+                if position is not None:
+                    return position
+        return None
+
     def handle_commission(self, asset: ExchangeAsset, cost: float) -> None:
-        # Adjust the cost basis of the stock if we own it
-        if asset in self.positions:
+        """Fold a commission into the position's cost basis, if the position is open.
+
+        ``positions`` is nested by exchange and account, so the old membership test
+        (``asset in self.positions``) compared an asset against exchange-name keys and never
+        matched. Commission was charged to cash correctly but never reached a cost basis for any
+        asset class, equities included.
+        """
+        position = self.get_position(asset=asset)
+        if position is not None:
             self._dirty_stats = True
-            self.adjust_commission_cost_basis(position=self.positions[asset], cost=cost)
+            self.adjust_commission_cost_basis(position=position, cost=cost)
 
     def adjust_commission_cost_basis(self, position: Position, cost: float):
         """
@@ -391,27 +411,39 @@ class PositionTracker:
 
         return net_cash_payment
 
-    def maybe_create_close_position_transaction(self, asset: ExchangeAsset, dt: datetime.datetime):
-        if not self.positions.get(asset):
+    def maybe_create_close_position_transaction(self, asset: ExchangeAsset,
+                                                dt: datetime.datetime) -> Transaction | None:
+        """Build the trade that liquidates ``asset`` at its last mark, or ``None`` if not held.
+
+        Used when a listing reaches its auto-close date and the position has to leave the book.
+
+        Two bugs lived here. The position was looked up as ``self.positions.get(asset)``, but
+        ``positions`` is nested ``{exchange: {account: {asset: Position}}}``, so an asset key never
+        matched and this always returned ``None`` -- nothing was ever closed, and an expired
+        listing stayed on the books at a stale mark for the rest of the run. And the price came
+        from ``self.data_bundle``, which this object does not have, so the lookup would have raised
+        had it ever been reached.
+        """
+        position = self.get_position(asset=asset)
+        if position is None or position.amount == 0:
             return None
 
-        amount = self.positions.get(asset).amount
-        # TODO: check this
-        price = self.data_bundle.get_spot_value(assets=asset, field="price", dt=dt,
-                                                data_frequency=self._data_frequency)
-
-        # Get the last traded price if price is no longer available
-        if isnan(price):
-            price = self.positions.get(asset).last_sale_price
+        price = position.last_sale_price
+        if price is None or isnan(price):
+            self._logger.warning(
+                "Cannot close an expired position: it has never been marked",
+                symbol=asset.symbol, dt=str(dt))
+            return None
 
         return Transaction(
             id=uuid.uuid4().hex,
             asset=asset,
-            amount=-amount,
+            amount=-position.amount,
             dt=dt,
             price=price,
             order_id=None,
-            exchange_name=None
+            exchange_name=position.exchange_name,
+            trading_account_id=position.trading_account_id,
         )
 
     def get_positions(self):

--- a/ziplime/finance/execution.py
+++ b/ziplime/finance/execution.py
@@ -268,3 +268,30 @@ def check_stoplimit_prices(price: float, label: str):
         raise BadOrderParameters(
             msg=f"Can't place a {label} order with a negative price."
         )
+
+
+def make_execution_style(limit_price: float | None = None, stop_price: float | None = None,
+                         style: ExecutionStyle | None = None) -> ExecutionStyle:
+    """Resolve the shorthand order arguments into a single execution style.
+
+    ``limit_price=N`` means :class:`LimitOrder`, ``stop_price=M`` means :class:`StopOrder`, both
+    together mean :class:`StopLimitOrder`, and neither means :class:`MarketOrder`. An explicit
+    ``style`` wins, but combining it with a loose price is an error rather than a silent choice of
+    one over the other.
+
+    Raises:
+        ValueError: if ``style`` is given alongside ``limit_price`` or ``stop_price``.
+    """
+    if style is not None:
+        if limit_price is not None or stop_price is not None:
+            raise ValueError(
+                "Pass either an execution style or limit_price/stop_price, not both."
+            )
+        return style
+    if limit_price is not None and stop_price is not None:
+        return StopLimitOrder(limit_price=limit_price, stop_price=stop_price)
+    if limit_price is not None:
+        return LimitOrder(limit_price=limit_price)
+    if stop_price is not None:
+        return StopOrder(stop_price=stop_price)
+    return MarketOrder()

--- a/ziplime/finance/slippage/no_slippage.py
+++ b/ziplime/finance/slippage/no_slippage.py
@@ -2,6 +2,7 @@ import datetime
 
 from ziplime.assets.entities.exchange_asset import ExchangeAsset
 from ziplime.exchanges.exchange import Exchange
+from ziplime.finance.domain.order import Order
 from ziplime.finance.slippage.slippage_model import SlippageModel
 
 
@@ -14,12 +15,21 @@ class NoSlippage(SlippageModel):
     This is primarily used for testing.
     """
 
-    @staticmethod
-    async def process_order(exchange: Exchange, dt: datetime.datetime, order):
-        return (
-            data.current(order.asset, "close"),
-            order.amount,
-        )
+    async def process_order(self, exchange: Exchange, dt: datetime.datetime, order: Order,
+                            price: float = None) -> tuple[float, float]:
+        """Fill the whole open amount at ``price``, or at the bar's close when none is given.
+
+        The signature had drifted from the one :meth:`SlippageModel.simulate` calls -- it took no
+        ``price`` and referred to a ``data`` that does not exist here -- so every order routed
+        through this model raised instead of filling.
+        """
+        if price is None:
+            current_val = await exchange.get_spot_value(
+                assets=frozenset({order.asset}), fields=frozenset({"close"}), dt=dt)
+            price = current_val["close"][0]
+        if price is None:
+            return None, 0
+        return price, order.open_amount
 
     async def order_target_percentage_maximum_quantity(self, exchange: Exchange, dt: datetime.datetime,
                                                        asset: ExchangeAsset,

--- a/ziplime/trading/trading_algorithm.py
+++ b/ziplime/trading/trading_algorithm.py
@@ -67,7 +67,7 @@ from ziplime.errors import (
     ZeroCapitalError, SymbolNotFound, BarSimulationError,
 )
 
-from ziplime.finance.execution import ExecutionStyle
+from ziplime.finance.execution import ExecutionStyle, make_execution_style
 from ziplime.finance.asset_restrictions import Restrictions
 from ziplime.finance.cancel_policy import CancelPolicy
 from ziplime.finance.asset_restrictions import (
@@ -1056,9 +1056,11 @@ class TradingAlgorithm(BaseTradingAlgorithm):
         return await self.order(
             asset,
             amount,
-            limit_price=limit_price,
-            stop_price=stop_price,
-            style=style,
+            # `order` takes an execution style, not loose prices: passing limit_price/stop_price
+            # through raised a TypeError, so order_value only ever worked by accident when the
+            # caller supplied a style of its own.
+            style=make_execution_style(limit_price=limit_price, stop_price=stop_price,
+                                       style=style),
             exchange_name=exchange_name
         )
 

--- a/ziplime/utils/run_algo.py
+++ b/ziplime/utils/run_algo.py
@@ -218,7 +218,10 @@ async def _prepare_algorithm(
         benchmark_fields=frozenset({"close"}),
         precalculated_series=benchmark_precalculated_series
     )
-    await benchmark_source.validate_benchmark(benchmark_asset=benchmark_asset)
+    if benchmark_asset is not None:
+        # Running without a benchmark is supported -- the zero-returns series above is built for
+        # exactly that case -- but validation used to run anyway and fail on the missing asset.
+        await benchmark_source.validate_benchmark(benchmark_asset=benchmark_asset)
 
     for exchange in reversed(await exchange_repository.get_all_exchanges()):
         custom_data_sources.insert(0, exchange)


### PR DESCRIPTION
Each of these is in a path every backtest goes through, so all of them affect equity-only runs today. Every fix comes with a regression test that fails on the current code; `tests/` had no tests before this, so these are also the first.

1. `PositionTracker.positions` is nested `{exchange: {account: {asset: Position}}}`, but `handle_commission` tested `asset in self.positions` -- comparing an asset against exchange-name keys, which never matched. **Commission was charged to cash but never reached a cost basis for any asset class.** Adds `get_position(asset)` and routes the lookup through it.

2. `maybe_create_close_position_transaction` had the same lookup bug, so it always returned `None` and auto-close never closed anything: a listing past its auto-close date stayed on the books at a stale mark for the rest of the run, still counted in exposure and leverage. It also read `self.data_bundle`, which that object does not have, and built the transaction with no exchange or account.

3. `Ledger.positions` handed out live `Position` objects. Performance packets keep what it returns, so closing a position in September rewrote what June's already-recorded row showed. Now returns snapshots. Cash and P&L were always right; the record was not.

4. `NoSlippage.process_order` took no `price` argument -- the caller passes one -- and referred to a name that does not exist in that scope. Every order routed through it raised instead of filling, for any asset class.

5. `order_value` forwarded `limit_price=`/`stop_price=` to `order`, which accepts neither, so it raised `TypeError` unless the caller happened to pass a style. Adds `make_execution_style`, which resolves the shorthand the docstring already documents.

6. `run_simulation` computed `equity_slippage`/`future_slippage` and then hardcoded fresh instances when building the exchange, so both parameters did nothing. `run_simulation_iter` already did this correctly.

7. The bundle load window filtered `pl.col("date") >= start_date.date()` -- a timezone-aware UTC column against a bare date, i.e. midnight UTC. That drops the first session for any exchange east of UTC: a Moscow session stamped 00:00 MSK is 21:00 UTC the day before. Exchanges west of UTC are unaffected either way.

8. `validate_benchmark` ran even when no benchmark asset was configured, raising on the missing asset. Running without a benchmark is supported -- the zero-returns series is built for exactly that case.